### PR TITLE
Fix patchops to add rather than replace

### DIFF
--- a/CE/Patches/MiliGuns_CE.xml
+++ b/CE/Patches/MiliGuns_CE.xml
@@ -171,8 +171,8 @@
 					<li>CE_AI_Pistol</li>
                 </weaponTags>
             </li>
-            <li Class="PatchOperationReplace">
-                <xpath>Defs/ThingDef[defName="DMS_PDW"]/tools</xpath>
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="DMS_PDW"]</xpath>
                 <value>
                     <tools Inherit="False"> 
 			            <li Class="CombatExtended.ToolCE">
@@ -235,8 +235,8 @@
 					<aimedBurstShotCount>3</aimedBurstShotCount>
                 </FireModes>
             </li>
-            <li Class="PatchOperationReplace">
-                <xpath>Defs/ThingDef[defName="DMS_AssaultPiercer"]/tools</xpath>
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="DMS_AssaultPiercer"]</xpath>
                 <value>
                     <tools Inherit="False"> 
 			            <li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
The vanilla PDW and Piercer do not have tools in their defs, so trying to patchopreplace them fails, which kills the sequence. This is a quick fix that doesn't rely on changing any of the base defs. If you've already patched the base that these guns may inherit from, just remove the two replace ops instead.