### PR TITLE
Melee changes request

### DIFF
--- a/1.5/CE/Patches/Weapons/MiliGuns_CE.xml
+++ b/1.5/CE/Patches/Weapons/MiliGuns_CE.xml
@@ -694,34 +694,34 @@
                     <tools>
                         <li Class="CombatExtended.ToolCE">
                             <label>handle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>4</power>
-							<cooldownTime>1.78</cooldownTime>
-							<chanceFactor>0.10</chanceFactor>
-							<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-						</li>
+			    <capacities>
+				<li>Poke</li>
+			    </capacities>
+			    <power>4</power>
+			    <cooldownTime>1.78</cooldownTime>
+			    <chanceFactor>0.10</chanceFactor>
+			    <armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+			    <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+			</li>
                         <li Class="CombatExtended.ToolCE">
-							<label>edge</label>
-							<capacities>
-								<li>Cut</li>
-							</capacities>
-							<power>40</power>
-							<cooldownTime>1.64</cooldownTime>
-							<armorPenetrationBlunt>6.48</armorPenetrationBlunt>
-                            <armorPenetrationSharp>14</armorPenetrationSharp>
-                            <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+			    <label>edge</label>
+			    <capacities>
+			        <li>Cut</li>
+			    </capacities>
+			    <power>40</power>
+			    <cooldownTime>1.64</cooldownTime>
+			    <armorPenetrationBlunt>6.48</armorPenetrationBlunt>
+			    <armorPenetrationSharp>14</armorPenetrationSharp>
+			    <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
                         </li>
                         <li Class="CombatExtended.ToolCE">
-							<label>point</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>18</power>
-							<cooldownTime>1.78</cooldownTime>
-							<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+			    <label>point</label>
+			    <capacities>
+				<li>Stab</li>
+			    </capacities>
+			    <power>18</power>
+			    <cooldownTime>1.78</cooldownTime>
+			    <armorPenetrationBlunt>2.0</armorPenetrationBlunt>
                             <armorPenetrationSharp>16</armorPenetrationSharp>
                         </li>
                     </tools>
@@ -736,17 +736,17 @@
             <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="DMS_Machete"]/statBases</xpath>
                 <value>
-					<Bulk>8</Bulk>
-					<MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
+		    <Bulk>8</Bulk>
+		    <MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
                 </value>
             </li>
             <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="DMS_Machete"]</xpath>
                 <value>
                     <equippedStatOffsets>
-						<MeleeCritChance>0.2</MeleeCritChance>
-						<MeleeParryChance>0.35</MeleeParryChance>
-						<MeleeDodgeChance>0.2</MeleeDodgeChance>
+			<MeleeCritChance>0.2</MeleeCritChance>
+			<MeleeParryChance>0.35</MeleeParryChance>
+			<MeleeDodgeChance>0.2</MeleeDodgeChance>
                     </equippedStatOffsets>
                 </value>
             </li>

--- a/1.5/CE/Patches/Weapons/MiliGuns_CE.xml
+++ b/1.5/CE/Patches/Weapons/MiliGuns_CE.xml
@@ -694,35 +694,35 @@
                     <tools>
                         <li Class="CombatExtended.ToolCE">
                             <label>handle</label>
-                            <capacities>
-                                <li>Poke</li>
-                            </capacities>
-                            <power>2</power>
-                            <chanceFactor>0.1</chanceFactor>
-                            <cooldownTime>1.5</cooldownTime>
-                            <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-                            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-                        </li>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.78</cooldownTime>
+							<chanceFactor>0.10</chanceFactor>
+							<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
                         <li Class="CombatExtended.ToolCE">
-                            <label>edge</label>
-                            <capacities>
-                                <li>Cut</li>
-                            </capacities>
-                            <power>31</power>
-                            <cooldownTime>0.83</cooldownTime>
-                            <armorPenetrationBlunt>2.88</armorPenetrationBlunt>
-                            <armorPenetrationSharp>16</armorPenetrationSharp>
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>40</power>
+							<cooldownTime>1.64</cooldownTime>
+							<armorPenetrationBlunt>6.48</armorPenetrationBlunt>
+                            <armorPenetrationSharp>14</armorPenetrationSharp>
                             <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
                         </li>
                         <li Class="CombatExtended.ToolCE">
-                            <label>point</label>
-                            <capacities>
-                                <li>Stab</li>
-                            </capacities>
-                            <power>11</power>
-                            <cooldownTime>0.94</cooldownTime>
-                            <armorPenetrationBlunt>1.28</armorPenetrationBlunt>
-                            <armorPenetrationSharp>12</armorPenetrationSharp>
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>1.78</cooldownTime>
+							<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+                            <armorPenetrationSharp>16</armorPenetrationSharp>
                         </li>
                     </tools>
                 </value>
@@ -736,17 +736,17 @@
             <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="DMS_Machete"]/statBases</xpath>
                 <value>
-                    <Bulk>5.4</Bulk>
-                    <MeleeCounterParryBonus>0.33</MeleeCounterParryBonus>
+					<Bulk>8</Bulk>
+					<MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
                 </value>
             </li>
             <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="DMS_Machete"]</xpath>
                 <value>
                     <equippedStatOffsets>
-                        <MeleeCritChance>0.56</MeleeCritChance>
-                        <MeleeParryChance>0.25</MeleeParryChance>
-                        <MeleeDodgeChance>0.34</MeleeDodgeChance>
+						<MeleeCritChance>0.2</MeleeCritChance>
+						<MeleeParryChance>0.35</MeleeParryChance>
+						<MeleeDodgeChance>0.2</MeleeDodgeChance>
                     </equippedStatOffsets>
                 </value>
             </li>
@@ -769,33 +769,23 @@
                             </capacities>
                             <power>2</power>
                             <chanceFactor>0.1</chanceFactor>
-                            <cooldownTime>1.5</cooldownTime>
+                            <cooldownTime>1.54</cooldownTime>
                             <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
                             <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-                            <extraMeleeDamages>
-                                <li>
-                                    <def>Stun</def>
-                                    <amount>5</amount>
-                                </li>
-                            </extraMeleeDamages>
                         </li>
                         <li Class="CombatExtended.ToolCE">
                             <label>edge</label>
                             <capacities>
                                 <li>Blunt</li>
                             </capacities>
-                            <power>10</power>
-                            <cooldownTime>0.83</cooldownTime>
+                            <power>8</power>
+                            <cooldownTime>1.36</cooldownTime>
                             <armorPenetrationBlunt>2.88</armorPenetrationBlunt>
                             <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
                             <extraMeleeDamages>
                                 <li>
                                     <def>EMP</def>
-                                    <amount>9</amount>
-                                </li>
-                                <li>
-                                    <def>Stun</def>
-                                    <amount>9</amount>
+                                    <amount>6</amount>
                                 </li>
                             </extraMeleeDamages>
                         </li>
@@ -804,21 +794,13 @@
                             <capacities>
                                 <li>Blunt</li>
                             </capacities>
-                            <power>14</power>
-                            <cooldownTime>0.94</cooldownTime>
+                            <power>10</power>
+                            <cooldownTime>1.54</cooldownTime>
                             <armorPenetrationBlunt>1.28</armorPenetrationBlunt>
                             <extraMeleeDamages>
                                 <li>
                                     <def>EMP</def>
-                                    <amount>18</amount>
-                                </li>
-                                <li>
-                                    <def>Burn</def>
-                                    <amount>5</amount>
-                                </li>
-                                <li>
-                                    <def>Stun</def>
-                                    <amount>5</amount>
+                                    <amount>6</amount>
                                 </li>
                             </extraMeleeDamages>
                         </li>
@@ -842,9 +824,9 @@
                 <xpath>Defs/ThingDef[defName="DMS_StunBaton"]</xpath>
                 <value>
                     <equippedStatOffsets>
-                        <MeleeCritChance>0.73</MeleeCritChance>
-                        <MeleeParryChance>0.5</MeleeParryChance>
-                        <MeleeDodgeChance>0.34</MeleeDodgeChance>
+                        <MeleeCritChance>1.46</MeleeCritChance>
+                        <MeleeParryChance>0.25</MeleeParryChance>
+                        <MeleeDodgeChance>0.20</MeleeDodgeChance>
                     </equippedStatOffsets>
                 </value>
             </li>

--- a/1.5/Defs/Things_Weapon/Weapon_Melee.xml
+++ b/1.5/Defs/Things_Weapon/Weapon_Melee.xml
@@ -53,7 +53,7 @@
 					</li>
 					<li>
 						<def>Stun</def>
-						<amount>5</amount>
+						<amount>4</amount>
 					</li>
 				</extraMeleeDamages>
 			</li>
@@ -67,19 +67,19 @@
 				<extraMeleeDamages>
 					<li>
 						<def>EMP</def>
-						<amount>9</amount>
+						<amount>18</amount>
 					</li>
 					<li>
 						<def>Stun</def>
-						<amount>9</amount>
+						<amount>6</amount>
 					</li>
 				</extraMeleeDamages>
 			</li>
 		</tools>
 		<costList>
 			<Polyester>20</Polyester>
-			<Tungsteel>20</Tungsteel>
-			<ComponentStamped>1</ComponentStamped>
+			<Tungsteel>35</Tungsteel>
+			<ComponentStamped>2</ComponentStamped>
 		</costList>
 		<recipeMaker>
 			<researchPrerequisites>
@@ -124,6 +124,7 @@
 					<li>Stab</li>
 				</capacities>
 				<power>23</power>
+				<armorPenetration>0.55</armorPenetration>
 				<cooldownTime>2.6</cooldownTime>
 			</li>
 			<li>
@@ -132,22 +133,28 @@
 					<li>Cut</li>
 				</capacities>
 				<power>23</power>
+				<armorPenetration>0.55</armorPenetration>
 				<cooldownTime>2.6</cooldownTime>
 			</li>
 		</tools>
 		<costList>
-			<Tungsteel>45</Tungsteel>
-			<ComponentStamped>1</ComponentStamped>
+			<Tungsteel>90</Tungsteel>
+			<ComponentStamped>2</ComponentStamped>
 		</costList>
 		<recipeMaker>
 			<researchPrerequisites>
 				<li>LongBlades</li>
-				<li>DMS_EquipmentAdvanced</li>
+				<li>DMS_EquipmentElite</li>
 			</researchPrerequisites>
 			<skillRequirements>
 				<Crafting>8</Crafting>
 			</skillRequirements>
 		</recipeMaker>
+		<modExtensions>
+			<li Class="DMS.HeavyEquippableExtension">
+				<EquippableDef>StandardAutomatroid</EquippableDef>
+			</li>
+		</modExtensions>
 	</ThingDef>
 	
 	<!-- Door Breaker, breach weapon for siegebreaker-->


### PR DESCRIPTION
Request for adjustment of both vanilla and CE values.
Slight reduction in perma-stun ability of the stun batton means it now needs to have multiple users to stun a single target forever. Already inflicts good damage/pain for vanilla and does have stun ability still, but if it hits 100% of the time it should no longer be able to lock the opponent in stun (but will get close, 2s stun on a 2.6s cooldown attack means the opponent only gets a moment to escape).
Machette buff to increase to static penetration that is a bit above performance of spear, but now needs same gear as other mainline mech weapons to better represent size/description. Price increased to around the cost of a longsword in terms of raw resources.

CE wise both have had their attack rate reduced to more consistent levels. Stun batton has had the secondary damage largely removed due to burn being covered by EMP burns instead, and stun inflicted via criticals instead. Can still stun most mechs for a fair amount of time but can no longer stun lock them to death as before.
Machette now has higher damage but slower striking slice. Switched sharp penetration a bit so the stab is slightly superior but it is a primarily cutting weapon so the base penetration is still higher.
It is worth noting that monosword does attack very quickly (which is what previous rate of attack seemed to be based off of), but it is sourcable only by purchase, whereas the machettes are fairly cheap. 