### PR TITLE
Power Skeleton Worktype

### DIFF
--- a/1.5/Defs/Things_Apparel/Civilian.xml
+++ b/1.5/Defs/Things_Apparel/Civilian.xml
@@ -283,7 +283,8 @@
 		<description>Physical enhancement equipment from array of neural prosthetic skeltons. It can increase the wearer's carry weight and mobility with effectively.</description>
 		<techLevel>Industrial</techLevel>
 		<recipeMaker>
-			<workSpeedStat>WorkSpeedGlobal</workSpeedStat>
+			<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+			<workSkill>Crafting</workSkill>
 			<effectWorking>ConstructMetal</effectWorking>
 			<soundWorking>Recipe_Machining</soundWorking>
 			<researchPrerequisite>DMS_MechBasis</researchPrerequisite>


### PR DESCRIPTION
Make the powered skeleton scale off of crafting like other production recipes, allowing for quality to not be completely random and assign to workers based on skill to the recipe.