### PR TITLE
Update DMS_Titles.xml

### DIFF
--- a/Languages/English/DefInjected/RoyalTitleDef/DMS_Titles.xml
+++ b/Languages/English/DefInjected/RoyalTitleDef/DMS_Titles.xml
@@ -2,58 +2,58 @@
 <LanguageData>
   
   <!-- EN: brigadier -->
-  <DMS_Brigadier.label>brigadier</DMS_Brigadier.label>
+  <DMS_Brigadier.label>Brigadier</DMS_Brigadier.label>
   <!-- EN: A senior rank above colonel, equivalent to a brigadier general or commodore, typically commanding a brigade of several thousand soldiers.. -->
-  <DMS_Brigadier.description>A senior rank above colonel, equivalent to a brigadier general or commodore, typically commanding a brigade of several thousand soldiers..</DMS_Brigadier.description>
+  <DMS_Brigadier.description>A senior rank above colonel, equivalent to a brigadier general or commodore, typically commanding a brigade composed of several thousand soldiers. This is the highest possible rank achievable in the colonial army.</DMS_Brigadier.description>
   
   <!-- EN: captain -->
-  <DMS_Captain.label>captain</DMS_Captain.label>
+  <DMS_Captain.label>Captain</DMS_Captain.label>
   <!-- EN: A commissioned officer rank historically corresponding to the command of a company of soldiers. -->
   <DMS_Captain.description>A commissioned officer rank historically corresponding to the command of a company of soldiers.</DMS_Captain.description>
   
   <!-- EN: colonel -->
-  <DMS_Colonel.label>colonel</DMS_Colonel.label>
+  <DMS_Colonel.label>Colonel</DMS_Colonel.label>
   <!-- EN: A colonel was typically in charge of a regiment in an army. -->
   <DMS_Colonel.description>A colonel was typically in charge of a regiment in an army.</DMS_Colonel.description>
   
   <!-- EN: corporal -->
-  <DMS_Corporal.label>corporal</DMS_Corporal.label>
+  <DMS_Corporal.label>Corporal</DMS_Corporal.label>
   <!-- EN: corporal is the lowest officer rank in the military system, leading a squad or a task forces. -->
-  <DMS_Corporal.description>corporal is the lowest officer rank in the military system, leading a squad or a task forces.</DMS_Corporal.description>
+  <DMS_Corporal.description>A corporal is the lowest non-commissioned officer rank in the military system, leading a squad or a specialized task force.</DMS_Corporal.description>
   
   <!-- EN: lieutenant -->
-  <DMS_Lieutenant.label>lieutenant</DMS_Lieutenant.label>
+  <DMS_Lieutenant.label>Lieutenant</DMS_Lieutenant.label>
   <!-- EN: A commissioned officer rank, which is typically the most senior of junior officer ranks. -->
   <DMS_Lieutenant.description>A commissioned officer rank, which is typically the most senior of junior officer ranks.</DMS_Lieutenant.description>
   
   <!-- EN: major -->
-  <DMS_Major.label>major</DMS_Major.label>
+  <DMS_Major.label>Major</DMS_Major.label>
   <!-- EN: A senior military officer rank, major is one rank above captain in armies and air forces, and one rank below colonel. -->
-  <DMS_Major.description>A senior military officer rank, major is one rank above captain in armies and air forces, and one rank below colonel.</DMS_Major.description>
+  <DMS_Major.description>A senior military officer rank, a major is one rank above captain in armies and air forces, and one rank below colonel.</DMS_Major.description>
   
   <!-- EN: pre-sergeant -->
-  <DMS_PreSergeant.label>pre-sergeant</DMS_PreSergeant.label>
+  <DMS_PreSergeant.label>Pre-sergeant</DMS_PreSergeant.label>
   <!-- EN: pre-sergeant is a rank specially for outsider enlistment with no formal training, Served as the representative of outsider military forces in the military system. -->
-  <DMS_PreSergeant.description>pre-sergeant is a rank specially for outsider enlistment with no formal training, Served as the representative of outsider military forces in the military system.</DMS_PreSergeant.description>
+  <DMS_PreSergeant.description>A pre-sergeant is a rank specially made for outsiders enlisting in the colonial army with no formal training, this rank is denoted as the representatiion of auxillary outsider military forces serving in the colonial military system.</DMS_PreSergeant.description>
   
   <!-- EN: private -->
-  <DMS_Private.label>private</DMS_Private.label>
+  <DMS_Private.label>Private</DMS_Private.label>
   <!-- EN: A private is a soldier, usually with the lowest rank in many armies. Soldiers with the rank of private may be conscripts or they may be professional (career) soldiers.. -->
-  <DMS_Private.description>A private is a soldier, usually with the lowest rank in many armies. Soldiers with the rank of private may be conscripts or they may be professional (career) soldiers..</DMS_Private.description>
+  <DMS_Private.description>A private is a proper soldier in the colonial army, and usually designated as the lowest rank in many armies. Soldiers with the rank of private may be conscripts or they may be professional (career) soldiers that have decided to enlist and did not go through officer schools..</DMS_Private.description>
   
   <!-- EN: Reservist -->
   <DMS_Reservist.label>Reservist</DMS_Reservist.label>
   <!-- EN: All citizens are reservist. it's not only a duty which also reconize you as a fully-respected individual. Most  citizens earn it while training for military service. The title is also offered to outsiders who act with honor in the eyes of the Armies. -->
-  <DMS_Reservist.description>All citizens are reservist. it's not only a duty which also reconize you as a fully-respected individual. Most  citizens earn it while training for military service. The title is also offered to outsiders who act with honor in the eyes of the Armies.</DMS_Reservist.description>
+  <DMS_Reservist.description>All citizens are reservists. It's not only a duty but a rank which also recognizes you as a fully-respected individual in this faction. Most citizens earn it while training for military service. The title is also offered to outsiders who act with honor in the eyes of the Colonial Armies, especially to pre-sergeants who have performed above and beyond.</DMS_Reservist.description>
   
   <!-- EN: sergeant -->
-  <DMS_Sergeant.label>sergeant</DMS_Sergeant.label>
+  <DMS_Sergeant.label>Sergeant</DMS_Sergeant.label>
   <!-- EN: a non-commissioned officer placed above the rank of a corporal. -->
-  <DMS_Sergeant.description>a non-commissioned officer placed above the rank of a corporal.</DMS_Sergeant.description>
+  <DMS_Sergeant.description>A non-commissioned officer placed above the rank of a corporal. It is the highest rank of the NCO corps before they take the path of the Warrant Officer and into the ranks of proper officers.</DMS_Sergeant.description>
   
   <!-- EN: warrant officer -->
-  <DMS_WarrantOfficer.label>warrant officer</DMS_WarrantOfficer.label>
+  <DMS_WarrantOfficer.label>Warrant Officer</DMS_WarrantOfficer.label>
   <!-- EN: The warrant officer is the first title of military officer duty. -->
-  <DMS_WarrantOfficer.description>The warrant officer is the first title of military officer duty.</DMS_WarrantOfficer.description>
+  <DMS_WarrantOfficer.description>The Warrant Officer is the rank that bridges the NCO and officer ranks. It is a stepping stone for enlisted soldiers to the path of higher ranks should they wish to and not stay as veteran NCOs and specialist warrant officers.</DMS_WarrantOfficer.description>
   
 </LanguageData>


### PR DESCRIPTION
Okay this one was a bit of a headache to me, so I have reworked the lore here: I think that Pre-sergeants are outsiders given rank, but are not recognized a full citizens of the Colonial faction until they get the Reservist rank. 

Then the proper ranking would be: Private to Corporal to Sergeant as NCOs or non-commissioned officers, the last two are backbone of armies as they are in the frontline and the sergeant serves as the connection between officers and enlisted. 

Warrant Officers are specialist troops, but can serve as a stepping stone for enlisted soldiers and sergeants who wish to become officers.

Then it's Lieutenant to Captain to Major to Colonel and finally the highest rank of Brigadier.